### PR TITLE
Fix Application Insights log filtering

### DIFF
--- a/src/collector/Program.cs
+++ b/src/collector/Program.cs
@@ -25,6 +25,17 @@ builder.Logging.Services.Configure<LoggerFilterOptions>(options =>
         {
             options.Rules.Remove(defaultRule);
         }
+
+        // Remove any generic rule that sets the minimum level to Warning
+        LoggerFilterRule? genericWarningRule = options.Rules.FirstOrDefault(rule => rule.ProviderName is null && rule.CategoryName is null && rule.LogLevel == LogLevel.Warning);
+
+        if (genericWarningRule is not null)
+        {
+            options.Rules.Remove(genericWarningRule);
+        }
+
+        // Ensure Information logs are captured
+        options.MinLevel = LogLevel.Information;
     });
 
 // Add HTTP client


### PR DESCRIPTION
## Summary
- ensure custom logs aren't filtered

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f64496408832590a960a3a3c4867a